### PR TITLE
Fix framecount for floating framerates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 - 10
 - 9
 - 8
-- 7
 cache:
   yarn: true
   directories:

--- a/src/core.js
+++ b/src/core.js
@@ -10,7 +10,7 @@ export default class SMPTE {
             throw new Error('Frame rate not supported');
         }
 
-        this.attributes = { df, frameRate: fr, roundFr: Math.round(fr) };
+        this.attributes = { df, frameRate: fr };
 
         if (typeof time === 'number') {
             if (time < 0) {
@@ -61,11 +61,12 @@ export default class SMPTE {
         this._frameCount = fc;
 
         let _fc = this.attributes.df ? this.dropFrame() : this._frameCount;
+        let roundFr = Math.round(this.attributes.frameRate);
 
-        this._hours = Math.floor(_fc / (this.attributes.roundFr * 3600)) % 24;
-        this._minutes = Math.floor(_fc / (this.attributes.roundFr * 60)) % 60;
-        this._seconds = Math.floor(_fc / this.attributes.roundFr) % 60;
-        this._frames = _fc % this.attributes.roundFr;
+        this._hours = Math.floor(_fc / (roundFr * 3600)) % 24;
+        this._minutes = Math.floor(_fc / (roundFr * 60)) % 60;
+        this._seconds = Math.floor(_fc / roundFr) % 60;
+        this._frames = _fc % roundFr;
     }
 
     get hours () {
@@ -149,7 +150,7 @@ export default class SMPTE {
      * @param {Number|String|Object} time Frame count, SMPTE object or string to be added
      */
     add (time, operation = 1) {
-        if (!(time instanceof SMPTE)) {
+        if (! (time instanceof SMPTE)) {
             time = new SMPTE(time, this.attributes.frameRate, this.attributes.df);
         } else if (time.attributes.frameRate !== this.attributes.frameRate) {
             throw new Error('Different frame rate timecodes can not be added');

--- a/src/index.js
+++ b/src/index.js
@@ -44,11 +44,7 @@ SMPTE.fromSeconds = function (seconds, fr = SMPTE.defaults.frameRate, df = SMPTE
         throw new Error('Frame rate not supported');
     }
 
-    let _fc = seconds;
-
-    _fc *= df ? fr : Math.round(fr);
-
-    return new SMPTE(Math.trunc(_fc), fr, df);
+    return new SMPTE(Math.trunc(seconds * fr), fr, df);
 };
 
 /**
@@ -81,7 +77,7 @@ SMPTE.isTimecodeFormatValid = function (timecode, df) {
         return false;
     }
 
-    if (!df && timecode.includes(';')) {
+    if (! df && timecode.includes(';')) {
         return false;
     }
 
@@ -99,7 +95,7 @@ SMPTE.isTimecodeFormatValid = function (timecode, df) {
  * @param {Boolean} df Boolean indicating if timecode is drop frame
  */
 SMPTE.isValidTimecode = function (timecode, fr = SMPTE.defaults.frameRate, df = SMPTE.defaults.dropFrame) {
-    if (!SMPTE.isTimecodeFormatValid(timecode, df)) {
+    if (! SMPTE.isTimecodeFormatValid(timecode, df)) {
         return false;
     }
 
@@ -109,7 +105,7 @@ SMPTE.isValidTimecode = function (timecode, fr = SMPTE.defaults.frameRate, df = 
         return false;
     }
 
-    if (df && (parts[1] % 10) !== 0 && parts[3] < 2 && parts[2] === 0) {
+    if (df && (parts[1] % 10 !== 0 && parts[3] < 2 && parts[2] === 0)) {
         return false;
     }
 
@@ -123,15 +119,14 @@ SMPTE.isValidTimecode = function (timecode, fr = SMPTE.defaults.frameRate, df = 
  * @param {Boolean} df Boolean indicating if timecode is drop frame
  */
 SMPTE.frameCountFromTimecode = function (timecode, fr = SMPTE.defaults.frameRate, df = SMPTE.defaults.dropFrame) {
-    if (!SMPTE.isValidTimecode(timecode, fr, df)) {
+    if (! SMPTE.isValidTimecode(timecode, fr, df)) {
         throw new Error('Invalid timecode');
     }
 
-    let roundFr = Math.round(fr);
     let parts = timecode.split(/:|;/).map(part => parseInt(part));
-    let _fc = (roundFr * 60 * 60 * parts[0])
-        + (roundFr * 60 * parts[1])
-        + (roundFr * parts[2])
+    let _fc = (fr * 60 * 60 * parts[0])
+        + (fr * 60 * parts[1])
+        + (fr * parts[2])
         + parts[3];
 
     if (df) {
@@ -140,7 +135,7 @@ SMPTE.frameCountFromTimecode = function (timecode, fr = SMPTE.defaults.frameRate
         return _fc - (2 * (totalMinutes - Math.floor(totalMinutes / 10)));
     }
 
-    return _fc;
+    return Math.round(_fc);
 };
 
 SMPTE.defaults = defaults;

--- a/test/unit/timecode.static.js
+++ b/test/unit/timecode.static.js
@@ -101,16 +101,52 @@ describe('SMPTE', function () {
             expect(() => fromSeconds(1, '')).to.throw(Error);
         });
 
-        it('should properly return frame count from milliseconds', function () {
+        it('should properly return frame count (24 fps)', function () {
             expect(fromSeconds(0).frameCount).to.equal(0);
-            expect(fromSeconds(0.042).frameCount).to.equal(1);
-            expect(fromSeconds(0.084).frameCount).to.equal(2);
+
             expect(fromSeconds(0.021).frameCount).to.equal(0);
             expect(fromSeconds(0.039).frameCount).to.equal(0);
+            expect(fromSeconds(0.042).frameCount).to.equal(1);
+            expect(fromSeconds(0.084).frameCount).to.equal(2);
+            expect(fromSeconds(300).frameCount).to.equal(7200);
+            expect(fromSeconds(600).frameCount).to.equal(14400);
+
+        });
+
+        it('should properly return frame count (25 fps)', function () {
             expect(fromSeconds(0.039, 25).frameCount).to.equal(0);
             expect(fromSeconds(0.040, 25).frameCount).to.equal(1);
             expect(fromSeconds(0.079, 25).frameCount).to.equal(1);
             expect(fromSeconds(0.080, 25).frameCount).to.equal(2);
+            expect(fromSeconds(300, 25).frameCount).to.equal(7500);
+            expect(fromSeconds(600, 25).frameCount).to.equal(15000);
+        });
+
+        it('should properly return frame count (23.976 fps)', function () {
+            expect(fromSeconds(0.041, 23.976).frameCount).to.equal(0);
+            expect(fromSeconds(0.042, 23.976).frameCount).to.equal(1);
+            expect(fromSeconds(0.083, 23.976).frameCount).to.equal(1);
+            expect(fromSeconds(0.084, 23.976).frameCount).to.equal(2);
+            expect(fromSeconds(300.301, 23.976).frameCount).to.equal(7200);
+            expect(fromSeconds(600.601, 23.976).frameCount).to.equal(14400);
+        });
+
+        it('should properly return frame count (29.97 fps)', function () {
+            expect(fromSeconds(0.033, 29.97).frameCount).to.equal(0);
+            expect(fromSeconds(0.034, 29.97).frameCount).to.equal(1);
+            expect(fromSeconds(0.066, 29.97).frameCount).to.equal(1);
+            expect(fromSeconds(0.067, 29.97).frameCount).to.equal(2);
+            expect(fromSeconds(300, 29.97).frameCount).to.equal(8991);
+            expect(fromSeconds(600, 29.97).frameCount).to.equal(17982);
+        });
+
+        it('should properly return frame count (30 fps)', function () {
+            expect(fromSeconds(0.033, 30).frameCount).to.equal(0);
+            expect(fromSeconds(0.034, 30).frameCount).to.equal(1);
+            expect(fromSeconds(0.066, 30).frameCount).to.equal(1);
+            expect(fromSeconds(0.067, 30).frameCount).to.equal(2);
+            expect(fromSeconds(300, 30).frameCount).to.equal(9000);
+            expect(fromSeconds(600, 30).frameCount).to.equal(18000);
         });
     });
 });

--- a/test/unit/timecode.static.js
+++ b/test/unit/timecode.static.js
@@ -110,7 +110,6 @@ describe('SMPTE', function () {
             expect(fromSeconds(0.084).frameCount).to.equal(2);
             expect(fromSeconds(300).frameCount).to.equal(7200);
             expect(fromSeconds(600).frameCount).to.equal(14400);
-
         });
 
         it('should properly return frame count (25 fps)', function () {


### PR DESCRIPTION
There are some cases which we require rounded framerate, however in some cases we can't use the rounded because it will not properly calculate